### PR TITLE
Install python-setuptools along with other dependencies. Fixes #3

### DIFF
--- a/pootle/Dockerfile
+++ b/pootle/Dockerfile
@@ -25,7 +25,8 @@ RUN /usr/local/bin/apt-install build-essential \
   libmysqlclient-dev \
   python-pip \
   python-xapian \
-  xapian-tools
+  xapian-tools \
+  python-setuptools
 # Install python packages
 RUN pip install -q virtualenv \
     MySQL-python \


### PR DESCRIPTION
python-setuptools is required by MySQL-python