### PR TITLE
Install wheel into pootle virtualenv

### DIFF
--- a/pootle/Dockerfile
+++ b/pootle/Dockerfile
@@ -33,7 +33,8 @@ RUN pip install -q virtualenv \
     flup \
     python-memcached \
     python-Levenshtein \
-    m2crypto
+    m2crypto \
+    wheel
 # Install pootle
 RUN pip install -I pootle==$POOTLE_VERSION
 # Configure pootle


### PR DESCRIPTION
to fix `error: invalid command 'bdist_wheel'`:-

    Step 7/24 : RUN pip install -I pootle==$POOTLE_VERSION
     ---> Running in [redacted]
    Collecting pootle==2.7.6
      Downloading Pootle-2.7.6.tar.bz2 (7.0MB)
    ... more ...
    Building wheels for collected packages: pootle, django-allauth, django-assets, django-contact-form, django-redis, django-transaction-hooks, cssmin, diff-match-patch, lxml, translate-toolkit, python-openid, webassets, oauthlib
      Running setup.py bdist_wheel for pootle: started
      Running setup.py bdist_wheel for pootle: finished with status 'error'
      Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-lOlkoR/pootle/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /tmp/tmpHXqQGkpip-wheel- --python-tag cp27:
      usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
         or: -c --help [cmd1 cmd2 ...]
         or: -c --help-commands
         or: -c cmd --help
    
      error: invalid command 'bdist_wheel'
    
      ----------------------------------------
      Failed building wheel for pootle
      Running setup.py clean for pootle
    ... more ...
